### PR TITLE
ToDo詳細画面のタイトル入力欄の幅を拡張

### DIFF
--- a/src/main/resources/templates/todo/todoDetails.html
+++ b/src/main/resources/templates/todo/todoDetails.html
@@ -29,7 +29,7 @@
           <!-- タイトル -->
           <div class="form-group">
             <label for="title">タイトル</label>
-            <input type="text" class="form-control w-50" name="title" id="title" th:value="*{title}"
+            <input type="text" class="form-control w-100" name="title" id="title" th:value="*{title}"
                 maxlength="20" placeholder="最大20文字まで" required>
             <div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" class="text-danger"></div>
           </div>


### PR DESCRIPTION
画面サイズが小さい場合に、タイトル全体を表示しきれない場合があったため