### PR TITLE
サイト全体のデザインの統一及び一部デザインの修正

### DIFF
--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -11,7 +11,7 @@
     <div class="container mb-5">
       <h2 th:text="${status} + ' '  + ${error}">エラータイトル</h2>
       <p class="text-danger">指定のページからアクセスが拒否されました</p>
-      <a href="#" th:href="@{/}" class="btn btn-secondary mt-4">トップページへ戻る</a>
+      <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>
     </div>
   </section>
 </body>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -12,8 +12,8 @@
       <h2>エラーが発生しました</h2>
       <div th:text="${errorMessage}" class="text-danger">エラーメッセージ</div>
       <p>時間をおいて再度実行しても同様の問題が発生する場合は、お手数ですが<a href="#" th:href="@{/inquiry}">お問い合わせ</a>
-      よりお伝えいただけますようお願いいたします。</p>
-      <a href="#" th:href="@{/}" class="btn btn-secondary mt-4">トップページへ戻る</a>
+      よりお伝えいただきますようお願いいたします。</p>
+      <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>
     </div>
   </section>
 

--- a/src/main/resources/templates/exclude/completeExclude.html
+++ b/src/main/resources/templates/exclude/completeExclude.html
@@ -10,7 +10,7 @@
   <section layout:fragment="content">
     <div class="container mb-5">
       <h2>ユーザー登録の解除が完了しました</h2>
-      <h4>ご利用ありがとうございました！！</h4>
+      <h4 class="mt-4">ご利用ありがとうございました！！</h4>
       <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>
     </div>
   </section>

--- a/src/main/resources/templates/exclude/excludeForm.html
+++ b/src/main/resources/templates/exclude/excludeForm.html
@@ -9,7 +9,11 @@
 <body th:with="authUserId=${#authentication.principal.username}">
   <section layout:fragment="content">
     <div class="container mb-5">
-      <h2>ユーザー登録解除</h2>
+      <h2 class="p-2" style="background-color: #c0c0c0;">
+	      <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-person-x-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+	        <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm6.146-2.854a.5.5 0 0 1 .708 0L14 6.293l1.146-1.147a.5.5 0 0 1 .708.708L14.707 7l1.147 1.146a.5.5 0 0 1-.708.708L14 7.707l-1.146 1.147a.5.5 0 0 1-.708-.708L13.293 7l-1.147-1.146a.5.5 0 0 1 0-.708z"/>
+	      </svg>ユーザー登録解除
+      </h2>
       <p>以下のユーザーの登録を解除します。<br>
       よろしければ、確認のためにパスワードを入力して「登録解除確定」ボタンを押してください<br>
       <span class="text-danger">※登録解除をすると、同時に登録したToDoもすべて削除されます。<br>
@@ -24,7 +28,7 @@
 			  <div th:if="${not #strings.isEmpty(error)}"><span th:text="${error}" class="text-danger"></span></div>
 			   <!-- ログイン済みのユーザーIDをhiddenで送信 -->
 			  <input type="hidden" th:name="userId"  th:value="${authUserId}"><br>
-			  <input type="submit" class="btn btn-secondary" value="登録解除確定">
+			  <input type="submit" class="btn btn-primary" value="登録解除確定">
 			</form>
     </div>
   </section>

--- a/src/main/resources/templates/login/loginForm.html
+++ b/src/main/resources/templates/login/loginForm.html
@@ -9,7 +9,12 @@
 <body>
   <section layout:fragment="content">
 	  <div class="container mb-5">
-	   <h2>ログイン</h2>
+	   <h2 class="p-2" style="background-color: #c0c0c0;">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-box-arrow-in-right mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+           <path fill-rule="evenodd" d="M6 3.5a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 0-1 0v2A1.5 1.5 0 0 0 6.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-8A1.5 1.5 0 0 0 5 3.5v2a.5.5 0 0 0 1 0v-2z"/>
+           <path fill-rule="evenodd" d="M11.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H1.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
+        </svg>ログイン
+      </h2>
      <div class="row">
       <div class="col-lg mb-4">
         <p class="text-danger" th:if="${param.error}">ログイン情報に誤りがあります<br>

--- a/src/main/resources/templates/register/confirmRegister.html
+++ b/src/main/resources/templates/register/confirmRegister.html
@@ -9,7 +9,11 @@
 <body>
   <section layout:fragment="content">
     <div class="container">
-      <h2>ユーザー登録確認</h2>
+      <h2 class="p-2" style="background-color: #c0c0c0;">
+        <svg xmlns="http://www.w3.org/2000/svg" width="0.7em" height="0.7em" fill="currentColor" class="bi bi-check-lg mr-2" viewBox="0 0 16 16">
+				  <path d="M13.485 1.431a1.473 1.473 0 0 1 2.104 2.062l-7.84 9.801a1.473 1.473 0 0 1-2.12.04L.431 8.138a1.473 1.473 0 0 1 2.084-2.083l4.111 4.112 6.82-8.69a.486.486 0 0 1 .04-.045z"/>
+				</svg>ユーザー登録確認
+      </h2>
        <p>以下の内容でユーザー登録します。<br>
        よろしければ、「登録確定」ボタンをクリックしてください。</p>
        <h4>ユーザーID : <span th:text="${userForm.userId}"></span></h4>

--- a/src/main/resources/templates/register/registerForm.html
+++ b/src/main/resources/templates/register/registerForm.html
@@ -9,7 +9,11 @@
 <body>
   <section layout:fragment="content">
     <div class="container mb-5">
-      <h2>ユーザー登録</h2>
+      <h2 class="p-2" style="background-color: #c0c0c0;">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-person-plus-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.5-3a.5.5 0 0 1 .5.5V7h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V8h-1.5a.5.5 0 0 1 0-1H13V5.5a.5.5 0 0 1 .5-.5z"/>
+        </svg>ユーザー登録
+      </h2>
       <div th:if="${not #strings.isEmpty(error)}">
         <span th:text="${error}" class="text-danger">エラーメッセージ</span>
       </div>

--- a/src/main/resources/templates/todo/addTodo.html
+++ b/src/main/resources/templates/todo/addTodo.html
@@ -9,13 +9,18 @@
 <body>
   <section layout:fragment="content">
     <div class="container mb-5">
-    <h2>ToDoの追加</h2>
+    <h2 class="p-2" style="background-color: #c0c0c0;">
+      <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-plus mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+         <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7z"/>
+      </svg>ToDoの追加
+    </h2>
       <div class="bg-light mt-3 p-4 rounded">
         <form action="#" th:action="@{/addTodo}" th:object=${todoForm} method="POST">
           <!-- タイトル -->
           <div class="form-group">
             <label for="title">タイトル</label>
-            <input type="text" class="form-control w-50" name="title" id="title" th:value="*{title}"
+            <input type="text" class="form-control w-100" name="title" id="title" th:value="*{title}"
                 maxlength="20" placeholder="最大20文字まで" required>
             <div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" class="text-danger"></div>
           </div>

--- a/src/main/resources/templates/todo/todoDetails.html
+++ b/src/main/resources/templates/todo/todoDetails.html
@@ -9,8 +9,13 @@
 <body>
   <section layout:fragment="content">
     <div class="container mb-5">
-    <h2>ToDoの詳細</h2>
-      <div class="bg-light mt-3 p-4 rounded">
+    <h2 class="p-2" style="background-color: #c0c0c0;">
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-card-text align-bottom mr-2" viewBox="0 0 16 16">
+			  <path d="M14.5 3a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h13zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/>
+			  <path d="M3 5.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 8a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 8zm0 2.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5z"/>
+			</svg>ToDoの詳細
+    </h2>
+      <div class="mt-3 p-4 rounded" style="background-color: #fafad2;">
         <div th:if="${completed} neq true">
           <strong>未完了のToDoです</strong>
           <a class="btn btn-primary text-light ml-4" href="#" 

--- a/src/main/resources/templates/todo/todoList.html
+++ b/src/main/resources/templates/todo/todoList.html
@@ -21,8 +21,18 @@
        <span class="h6">今日までのToDo<span class="badge badge-pill badge-light ml-2" th:text="${todayList.size()}">0</span></span></a>
 	    <a href="#" th:href="@{/todoList?listType=expired&sort=deadline&order=ASC}" class="badge badge-warning p-2">
 	      <span class="h6 text-light">期限切れのToDo<span class="badge badge-pill badge-light ml-2" th:text="${expiredList.size()}">0</span></span></a>
-	    <h4 class="mt-3" th:text="${#calendars.format(#calendars.createNowForTimeZone('Asia/Tokyo'), '今日はyyyy年MM月dd日です')}"></h4>
+	    <div class="bg-light mt-3 p-2 rounded">
+		    <h4 >こんにちは<span sec:authentication="principal.username"></span>さん</h4>
+		    <h4 th:text="${#calendars.format(#calendars.createNowForTimeZone('Asia/Tokyo'), '今日はyyyy年MM月dd日です')}"></h4>
+	    </div>
 	    
+	    <h2 class="mt-5 mb-3 p-2" style="background-color: #c0c0c0;">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-week mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+           <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+           <path d="M11 6.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-5 3a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
+         </svg>ToDo一覧
+      </h2>
+      
 	    <div th:if="${todayList.size() ne 0}" class="mb-3">
 	     <div class="card">
         <div class="card-header" role="tab" id="todayListAlartHeader" style="background-color: #fafad2;">
@@ -39,11 +49,6 @@
         </div>
        </div>
 	    </div>
-	    
-	   <div class="p-2 rounded" style="background-color: #f0ffff;">
-	   <div class="clearfix mb-2">
-       <a href="#" th:href="@{/addTodo}" class="card-link btn btn-primary float-right">ToDoの追加</a>
-     </div>
 	    
 	   <div class="card">
 		  <ul class="nav nav-tabs" style="background-color:#fffafa;">
@@ -120,16 +125,18 @@
 			 </div>
 		  </div>
 	   </div>
-	   <div class="mt-2 mb-5">
-	     <div th:if="${listType == 'completed'}">
+	   <div class="mt-3">
+	     <div class="clearfix mb-4">
+	       <a href="#" th:href="@{/addTodo}" class="btn btn-primary float-right">ToDoの追加</a>
+	     </div>
+	     <div class="clearfix" th:if="${listType == 'completed'}">
         <a class="btn btn-secondary text-light float-right" href="#" th:href="@{/todoDetails/bulkDelete?target=completed}">完了ToDoを一括削除する</a>
       </div>
-      <div th:if="${listType == 'expired'}">
+      <div class="clearfix" th:if="${listType == 'expired'}">
         <a class="btn btn-secondary text-light float-right" href="#" th:href="@{/todoDetails/bulkDelete?target=expired}">期限切れToDoを一括削除する</a>
       </div>
-      </div>
-	   </div>
-	 </div>
+     </div>
+   </div>
   </section>
 </body>
 </html>


### PR DESCRIPTION
・ログイン画面
見出しのデザインを統一

・ユーザー登録フォーム画面
見出しのデザインを統一

・ユーザー登録確認画面
見出しのデザインを統一

・ユーザー登録解除フォーム画面
見出しのデザインを統一
フォームの送信ボタンの色をprimaryに統一

・登録解除完了画面
見出しと本文の間隔が近すぎたので拡張

・ToDo一覧画面
画面上部にログインユーザー名の表示を追加
一覧の上に見出しを追加
「ToDoの追加」ボタンの位置を変更
一覧部分の背景色を削除

・ToDo追加画面
見出しのデザインを統一
画面サイズが小さいときにタイトル入力欄の幅が小さすぎる点を修正

・ToDo追加画面
見出しのデザインを統一
完了状態の表示部の背景色を変更し、フォームとの分離を分かりやすくした

・エラー画面
トップに戻るボタンの色をsecondary->primaryに
本文を微修正

・403エラー画面
トップに戻るボタンの色をsecondary->primaryに