### PR TITLE
お問い合わせフォームの入力項目にお名前、メールアドレスを追加

### DIFF
--- a/src/main/java/com/example/app/inquiry/InquiryController.java
+++ b/src/main/java/com/example/app/inquiry/InquiryController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.domain.service.inquiry.InquiryService;
 
@@ -40,22 +39,17 @@ public class InquiryController {
   }
 
   /**
-   * フォームの入力内容を基にお問い合わせを送信する. 
-   * 入力内容に不備がある場合はフォワードでお問い合わせ画面に遷移.
-   * 送信が完了した場合はリダイレクトでお問い合わせ画面に遷移.
-   *  メール送信処理でエラーが発生した場合はエラー画面に遷移.
+   * フォームの入力内容を基にお問い合わせを送信する. 入力内容に不備がある場合はフォワードでお問い合わせ画面に遷移.
+   * 送信が完了した場合はリダイレクトでお問い合わせ完了処理に遷移. メール送信処理でエラーが発生した場合はエラー画面に遷移.
    * @param form お問い合わせフォーム
    * @param result フォームのバリデーション結果
    * @param model モデル
-   * @param redirectAttributes リダイレクト先との連携データを格納
-   * @return お問い合わせ画面(メール処理エラー時はエラー画面)
    */
   @PostMapping
-  String sendInquiry(@Validated InquiryForm form, BindingResult result, Model model,
-      RedirectAttributes redirectAttributes) {
+  String sendInquiry(@Validated InquiryForm form, BindingResult result, Model model) {
 
     if (result.hasErrors()) {
-      model.addAttribute("inquiryMsg", "お問い合わせが送信できませんでした");
+      model.addAttribute("inquiryMsg", "入力内容にエラーがあります");
       return inquiryForm(model);
     }
 
@@ -66,7 +60,16 @@ public class InquiryController {
       return "error/error";
     }
 
-    redirectAttributes.addFlashAttribute("inquiryMsg", "お問い合わせを送信しました");
-    return "redirect:/inquiry";
+    return "redirect:/inquiry/complete";
+  }
+
+  /**
+   * お問い合わせ完了画面に遷移する.
+   * @param modle モデル
+   * @return お問い合わせ完了画面
+   */
+  @GetMapping("/complete")
+  String completeInquiry(Model modle) {
+    return "inquiry/completeInquiry";
   }
 }

--- a/src/main/java/com/example/app/inquiry/InquiryForm.java
+++ b/src/main/java/com/example/app/inquiry/InquiryForm.java
@@ -2,6 +2,7 @@ package com.example.app.inquiry;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -17,7 +18,23 @@ import lombok.Setter;
 @Setter
 public class InquiryForm implements Serializable {
 
+  /** お名前の最大文字数 */
+  private static final int NAME_MAX_LENGTH = 50;
+  /** メールアドレスの最大文字数 */
+  private static final int EMAIL_MAX_LENGTH = 100;
+  /** 本文の最大文字数 */
   private static final int TEXT_MAX_LENGTH = 400;
+
+  /** お名前. */
+  @NotNull(message = "お名前が入力されていません")
+  @Size(max = NAME_MAX_LENGTH, message = "文字数オーバーです")
+  private String name;
+
+  /** メールアドレス. */
+  @NotNull(message = "メールアドレスが入力されていません")
+  @Size(max = EMAIL_MAX_LENGTH, message = "文字数オーバーです")
+  @Email(message = "メールアドレスが適切ではありません")
+  private String email;
 
   /** 分類. */
   @Pattern(regexp = "ご意見・ご要望|不具合について|その他", message = "お問い合わせの分類が不正です")

--- a/src/main/java/com/example/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/config/WebSecurityConfig.java
@@ -40,7 +40,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
       //ユーザー登録画面は全て許可
       .antMatchers("/register", "/register/**").permitAll()
       //お問い合わせ送信は全て許可
-      .antMatchers("/inquiry").permitAll()
+      .antMatchers("/inquiry", "/inquiry/**").permitAll()
       .antMatchers("/js/**", "/css/**", "/img/**").permitAll()
       .antMatchers("/**").authenticated()
       .and()

--- a/src/main/java/com/example/domain/service/inquiry/InquiryServiceImpl.java
+++ b/src/main/java/com/example/domain/service/inquiry/InquiryServiceImpl.java
@@ -21,10 +21,10 @@ public class InquiryServiceImpl implements InquiryService {
   public void sendMail(InquiryForm form) {
     SimpleMailMessage msg = new SimpleMailMessage();
 
-    msg.setFrom(System.getenv("TODO_APP_MAIL_ADDRESS"));
     msg.setTo(System.getenv("TODO_APP_MAIL_ADDRESS"));
     msg.setSubject("フォームからのお問い合わせ : " + form.getType());
-    msg.setText(form.getText());
+    msg.setText("お名前 : " + form.getName() + System.lineSeparator() + "メールアドレス : " + form.getEmail()
+        + System.lineSeparator() + System.lineSeparator() + form.getText());
 
     sender.send(msg);
   }

--- a/src/main/resources/templates/inquiry/completeInquiry.html
+++ b/src/main/resources/templates/inquiry/completeInquiry.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+          xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+          xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+          layout:decorate="~{layout/layout}">
+<head>
+<title>ToDo!! | お問い合わせ送信完了</title>
+</head>
+<body>
+  <section layout:fragment="content">
+    <div class="container mb-5">
+      <h2>お問い合わせを送信しました</h2>
+      <p class="mt-4">お問い合わせいただいた内容につきまして、48時間以内にメールにて返信いたします。<br>
+      恐れ入りますが、返信をお待ちいただきますようお願い申し上げます。
+      </p>
+      <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/src/main/resources/templates/inquiry/inquiry.html
+++ b/src/main/resources/templates/inquiry/inquiry.html
@@ -26,6 +26,20 @@
       </div>
       <!-- お問い合わせフォーム -->
       <form action="#" th:action="@{/inquiry}" th:object="${inquiryForm}" method="POST">
+        <!-- お名前 -->
+        <div class="form-group">
+          <label for="name">お名前</label>
+          <input type="text" class="form-control w-100" name="name" id="name" th:value="*{name}" maxlength="50" 
+          placeholder="最大50文字まで"required>
+          <div th:if="${#fields.hasErrors('name')}" th:errors="*{name}" class="text-danger"></div>
+        </div>
+        <!-- メールアドレス -->
+        <div class="form-group">
+          <label for="email">メールアドレス </label>
+          <input type="email" class="form-control w-100" name="email" id="email" th:value="*{email}" maxlength="100" 
+          placeholder="最大100文字まで"required>
+          <div th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="text-danger"></div>
+        </div>
         <!-- お問い合わせの分類 -->
         <div class="form-group">
           <label for="type">お問い合わせの分類</label>
@@ -40,7 +54,7 @@
         <div class="form-group">
           <label for="text">お問い合わせ内容</label>
           <textarea class="form-control" th:field="*{text}" cols="40" rows="4" maxlength="400"
-              placeholder="最大400文字まで"></textarea>
+              placeholder="最大400文字まで" required></textarea>
           <div th:if="${#fields.hasErrors('text')}" th:errors="*{text}" class="text-danger"></div>
         </div>
         <!-- 送信ボタン -->
@@ -48,7 +62,8 @@
       </form>
       
       <div class="mt-3">
-        <p class="text-danger">※お問い合わせの内容への返信はいたしかねます。</p>
+        <p class="text-danger">※メールアドレスが正しくない場合、お問い合わせに返信をすることができません。<br>
+        送信を行う前に、誤りがないか再度ご確認をお願いいたします。</p>
       </div>
     </div>
   </section>

--- a/src/test/java/com/example/app/inquiry/InquiryControllerTest.java
+++ b/src/test/java/com/example/app/inquiry/InquiryControllerTest.java
@@ -56,6 +56,8 @@ class InquiryControllerTest {
 
     @BeforeEach
     void setUp() {
+      form.setName("お問い合わせユーザー名");
+      form.setEmail("InquiryTest@mail.com");
       form.setType("ご意見・ご要望");
       form.setText("お問い合わせ本文");
     }
@@ -84,16 +86,28 @@ class InquiryControllerTest {
         doThrow(new MailSendException("エラーメッセージ")).when(service).sendMail(form);
 
         mockMvc.perform(post("/inquiry").with(csrf()).flashAttr("inquiryForm", form)).andExpect(
-            status().isOk()).andExpect(model().attributeExists("errorMessage")).andExpect(view().name(
-                "error/error"));
+            status().isOk()).andExpect(model().attributeExists("errorMessage")).andExpect(view()
+                .name("error/error"));
       }
 
       @Test
-      @DisplayName("正常に処理が完了した場合、お問い合わせ画面にリダイレクト")
+      @DisplayName("正常に処理が完了した場合、お問い合わせ完了処理にリダイレクト")
       void successSendInquiry() throws Exception {
         mockMvc.perform(post("/inquiry").with(csrf()).flashAttr("inquiryForm", form)).andExpect(
-            status().isFound()).andExpect(view().name("redirect:/inquiry"));
+            status().isFound()).andExpect(view().name("redirect:/inquiry/complete"));
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("completeInquiry()のテスト")
+  class TestcompleteInquiry {
+
+    @Test
+    @DisplayName("お問い合わせ完了画面に遷移する")
+    void correctTransition() throws Exception {
+      mockMvc.perform(get("/inquiry/complete")).andExpect(status().isOk()).andExpect(view().name(
+          "inquiry/completeInquiry"));
     }
   }
 }

--- a/src/test/java/com/example/app/inquiry/InquiryFormTest.java
+++ b/src/test/java/com/example/app/inquiry/InquiryFormTest.java
@@ -27,8 +27,96 @@ class InquiryFormTest {
 
   @BeforeEach
   void setUp() {
+    form.setName("お問い合わせユーザー名");
+    form.setEmail("InquiryTest@mail.com");
     form.setType("ご意見・ご要望");
     form.setText("お問い合わせの本文");
+  }
+
+  @DisplayName("全ての入力項目が適切である場合、エラーが存在しない")
+  void allItemValidationTrue() {
+    validator.validate(form, bindingResult);
+
+    assertThat(bindingResult.hasErrors(), is(false));
+  }
+
+  @Nested
+  @DisplayName("nameのバリデーションテスト")
+  class TestName {
+
+    @Test
+    @DisplayName("入力内容が空(null)の場合、エラーが存在する")
+    void nameValidationFalseForBlank() {
+      form.setName(null);
+      validator.validate(form, bindingResult);
+
+      assertThat(bindingResult.hasFieldErrors("name"), is(true));
+      assertThat(bindingResult.getFieldErrors("name").stream().anyMatch(it -> it.getDefaultMessage()
+          .equals("お名前が入力されていません")), is(true));
+    }
+
+    @Test
+    @DisplayName("入力内容が文字数オーバーの場合、エラーが存在する")
+    void nameValidationFalseForOver() {
+      // 最大文字数を超えた51文字の文字列を用意
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < 51; i++) {
+        sb.append("a");
+      }
+      String longStr = sb.toString();
+
+      form.setName(longStr);
+      validator.validate(form, bindingResult);
+
+      assertThat(bindingResult.hasFieldErrors("name"), is(true));
+      assertThat(bindingResult.getFieldErrors("name").stream().anyMatch(it -> it.getDefaultMessage()
+          .equals("文字数オーバーです")), is(true));
+    }
+  }
+
+  @Nested
+  @DisplayName("emailのバリデーションテスト")
+  class TestEmail {
+
+    @Test
+    @DisplayName("入力内容が空(null)の場合、エラーが存在する")
+    void emailValidationFalseForBlank() {
+      form.setEmail(null);
+      validator.validate(form, bindingResult);
+
+      assertThat(bindingResult.hasFieldErrors("email"), is(true));
+      assertThat(bindingResult.getFieldErrors("email").stream().anyMatch(it -> it
+          .getDefaultMessage().equals("メールアドレスが入力されていません")), is(true));
+    }
+
+    @Test
+    @DisplayName("入力内容が文字数オーバーの場合、エラーが存在する")
+    void emailValidationFalseForOver() {
+      // 最大文字数を超えた101文字の文字列を用意
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < 101; i++) {
+        sb.append("a");
+      }
+      String longStr = sb.toString();
+
+      form.setEmail(longStr);
+      validator.validate(form, bindingResult);
+
+      assertThat(bindingResult.hasFieldErrors("email"), is(true));
+      assertThat(bindingResult.getFieldErrors("email").stream().anyMatch(it -> it
+          .getDefaultMessage().equals("文字数オーバーです")), is(true));
+    }
+
+    @Test
+    @DisplayName("入力内容がメールアドレスとして適切でない場合、エラーが存在する")
+    void emailValidationFalseForFormat() {
+      form.setEmail("WrongMail$mail.com");
+      validator.validate(form, bindingResult);
+
+      assertThat(bindingResult.hasFieldErrors("email"), is(true));
+      assertThat(bindingResult.getFieldErrors("email").stream().anyMatch(it -> it
+          .getDefaultMessage().equals("メールアドレスが適切ではありません")), is(true));
+    }
   }
 
   @Nested
@@ -36,16 +124,17 @@ class InquiryFormTest {
   class TestType {
 
     @ParameterizedTest
-    @DisplayName("正しい分類が指定されている場合")
+    @DisplayName("分類の選択肢に存在する入力内容の場合、エラーが存在しない")
     @CsvSource({ "ご意見・ご要望", "不具合について", "その他" })
     void typeValidationTrue(String type) {
       form.setType(type);
       validator.validate(form, bindingResult);
+
       assertThat(bindingResult.hasFieldErrors("type"), is(false));
     }
 
     @Test
-    @DisplayName("入力内容が不正の場合")
+    @DisplayName("分類の選択肢に存在しない入力内容の場合、エラーが存在する")
     void typeValidationFalse() {
       form.setType("不正な分類");
       validator.validate(form, bindingResult);
@@ -61,14 +150,7 @@ class InquiryFormTest {
   class TestText {
 
     @Test
-    @DisplayName("入力内容が正しい場合")
-    void textValidationTrue() {
-      validator.validate(form, bindingResult);
-      assertThat(bindingResult.hasFieldErrors("text"), is(false));
-    }
-
-    @Test
-    @DisplayName("入力内容が空(null)の場合")
+    @DisplayName("入力内容が空(null)の場合、エラーが存在する")
     void textValidationFalseForBlank() {
       form.setText(null);
       validator.validate(form, bindingResult);
@@ -79,16 +161,16 @@ class InquiryFormTest {
     }
 
     @Test
-    @DisplayName("入力内容が文字数オーバーの場合")
+    @DisplayName("入力内容が文字数オーバーの場合、エラーが存在する")
     void textValidationFalseForOver() {
       // 最大文字数を超えた401文字の文字列を用意
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < 401; i++) {
         sb.append("a");
       }
-      String memo = sb.toString();
+      String longStr = sb.toString();
 
-      form.setText(memo);
+      form.setText(longStr);
       validator.validate(form, bindingResult);
 
       assertThat(bindingResult.hasFieldErrors("text"), is(true));


### PR DESCRIPTION
お問い合わせフォームクラスに必要なフィールドを追加
送信されるメール本文にお名前、メールアドレスを記載するように変更
お問い合わせ完了画面を作成.送信完了後はこちらに遷移するように変更
お問い合わせ完了画面を認証処理の対象外に設定