### PR TITLE
md未満の画面サイズの場合に、画面下部にスクロールに追従するボトムメニューが表示されるように変更

### DIFF
--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -1,12 +1,5 @@
 @charset "UTF-8";
 
-body { 
-	padding-top: 100px;
-	display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
 td {
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -15,17 +8,16 @@ td {
 }
 
 .contents_top {
-  padding-top:100px;
-  margin-top:-100px;
+  padding-top:40px;
 }
 
 .contents {
-	padding-top:100px;
+	padding-top:70px;
 }
 
 #page_top {
   position: fixed;
-  bottom: 20px;
+  bottom: 90px;
   right: 10px;
   font-size: 20px;
   line-height: 1;

--- a/src/main/resources/static/js/layout.js
+++ b/src/main/resources/static/js/layout.js
@@ -1,3 +1,4 @@
+/* ページトップへのスクロールボタンの動作 */
 $(function(){
   var pagetop = $('#page_top');
   pagetop.hide();
@@ -11,5 +12,17 @@ $(function(){
   pagetop.click(function () {
      $('body, html').animate({ scrollTop: 0 }, 500);
      return false;
+  });
+});
+
+/* ボトムメニューの動作 */
+$(function(){
+  var bottommenu = $('#bottom_menu');
+  $(window).scroll(function () {
+     if ($(this).scrollTop() > 1200) {
+          bottommenu.fadeOut();
+     } else {
+          bottommenu.fadeIn();
+     }
   });
 });

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2 th:text="${status} + ' '  + ${error}">エラータイトル</h2>
       <p class="text-danger">指定のページからアクセスが拒否されました</p>
       <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2 th:text="${status} + ' '  + ${error}">エラータイトル</h2>
       <p class="text-danger">指定されたページは存在しません<br>
       URLに誤りがないか再度ご確認ください</p>

--- a/src/main/resources/templates/error/408.html
+++ b/src/main/resources/templates/error/408.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2 th:text="${status} + ' '  + ${error}">エラータイトル</h2>
       <p class="text-danger">リクエストがタイムアウトしました</p>
       <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>

--- a/src/main/resources/templates/error/503.html
+++ b/src/main/resources/templates/error/503.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2 th:text="${status} + ' '  + ${error}">エラータイトル</h2>
       <p class="text-danger">サーバーにアクセスが集中しています<br>
       時間を空けて再度アクセスをお試しください</p>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2>エラーが発生しました</h2>
       <div th:text="${errorMessage}" class="text-danger">エラーメッセージ</div>
       <p>時間をおいて再度実行しても同様の問題が発生する場合は、お手数ですが<a href="#" th:href="@{/inquiry}">お問い合わせ</a>

--- a/src/main/resources/templates/exclude/completeExclude.html
+++ b/src/main/resources/templates/exclude/completeExclude.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h3>ユーザー登録の解除が完了しました</h3>
       <h4 class="mt-4">ご利用ありがとうございました！！</h4>
       <a href="#" th:href="@{/}" class="btn btn-primary mt-4">トップページへ戻る</a>

--- a/src/main/resources/templates/exclude/excludeForm.html
+++ b/src/main/resources/templates/exclude/excludeForm.html
@@ -8,7 +8,7 @@
 </head>
 <body th:with="authUserId=${#authentication.principal.username}">
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h4 class="p-2" style="background-color: #b0c4de;">
 	      <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-person-x-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
 	        <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm6.146-2.854a.5.5 0 0 1 .708 0L14 6.293l1.146-1.147a.5.5 0 0 1 .708.708L14.707 7l1.147 1.146a.5.5 0 0 1-.708.708L14 7.707l-1.146 1.147a.5.5 0 0 1-.708-.708L13.293 7l-1.147-1.146a.5.5 0 0 1 0-.708z"/>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,7 +5,6 @@
           layout:decorate="~{layout/layout}">
 <head>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<script src="/js/layout.js"></script>
 <title>ToDo!!</title>
 </head>
 <body>
@@ -43,41 +42,6 @@
           <img th:src="@{/img/bunbougu_memo.png}" class="img-fluid d-none d-lg-block" alt="メモ帳のイラスト" title="メモ帳のイラスト">
         </div>
       </div>
-    </div>
-    
-    <!-- ナビバーが折りたたまれるlg未満の画面サイズの場合は操作補助用のボタンを表示 -->
-    <div class="container my-5 d-lg-none">
-      <div class="mx-auto" style="width:300px;">
-	      <!--* 非ログイン状態の場合のボタン表示 *-->
-	      <div sec:authorize="isAnonymous()">
-		      <a class="btn text-light mr-3" href="#" th:href="@{/loginForm}" role="button" style="background-color :#006890;">
-			      <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-box-arrow-in-right mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-			         <path fill-rule="evenodd" d="M6 3.5a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 0-1 0v2A1.5 1.5 0 0 0 6.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-8A1.5 1.5 0 0 0 5 3.5v2a.5.5 0 0 0 1 0v-2z"/>
-			         <path fill-rule="evenodd" d="M11.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H1.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
-			      </svg>ログイン
-		      </a>
-		      <a class="btn text-light" href="#" th:href="@{/register}" role="button" style="background-color :#006890;">
-			      <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-person-plus-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-			        <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.5-3a.5.5 0 0 1 .5.5V7h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V8h-1.5a.5.5 0 0 1 0-1H13V5.5a.5.5 0 0 1 .5-.5z"/>
-			      </svg>ユーザー登録
-		      </a>
-		    </div>
-		    <!--* ログイン状態の場合のボタン表示 *-->
-		    <div sec:authorize="isAuthenticated()">
-		     <a class="btn text-light mr-3" href="#" th:href="@{/todoList}" style="background-color :#006890;">
-	         <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-calendar-week mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-	           <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
-	           <path d="M11 6.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-5 3a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
-	         </svg>ToDo一覧
-	       </a>
-	       <a class="btn text-light" href="#" th:href="@{/addTodo}" style="background-color :#006890;">
-	         <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-calendar-plus mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-	           <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
-	            <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7z"/>
-	         </svg>ToDoの追加
-	       </a>
-		    </div>
-	    </div>
     </div>
     
     <div id="aboutThisSite" class="container contents">

--- a/src/main/resources/templates/inquiry/completeInquiry.html
+++ b/src/main/resources/templates/inquiry/completeInquiry.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h2>お問い合わせを送信しました</h2>
       <p class="mt-4">お問い合わせいただいた内容につきまして、48時間以内にメールにて返信いたします。<br>
       恐れ入りますが、返信をお待ちいただきますようお願い申し上げます。

--- a/src/main/resources/templates/inquiry/inquiry.html
+++ b/src/main/resources/templates/inquiry/inquiry.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h4 class="p-2" style="background-color: #b0c4de;">
         <svg xmlns="http://www.w3.org/2000/svg" width="0.85em" height="0.85em" fill="currentColor" class="bi bi-chat-left-text mr-2" viewBox="0 0 16 16">
           <path d="M14 1a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H4.414A2 2 0 0 0 3 11.586l-2 2V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12.793a.5.5 0 0 0 .854.353l2.853-2.853A1 1 0 0 1 4.414 12H14a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -15,12 +15,15 @@
 <!--* jQuery, Bootstrap JS *-->
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js" integrity="sha384-LtrjvnR4Twt/qOuYxE721u19sVFLVSA4hf/rRt6PrZTmiPltdZcI7q7PXQBYTKyf" crossorigin="anonymous"></script>
+
+<!-- * レイアウト用のJS -->
+<script src="/js/layout.js"></script>
 <title>レイアウトタイトル</title>
 </head>
 <body>
 <header>
   <!--* ナビバー *-->
-  <nav class="navbar navbar-expand-lg navbar-light fixed-top" style="background-color: #b0c4de;">
+  <nav class="navbar navbar-expand-md navbar-light" style="background-color: #b0c4de;">
     <a class="navbar-brand ml-2 ml-lg-4" href="#" th:href="@{/}"><em class="h3">ToDo!!</em></a>
     <button class="navbar-toggler mr-3" type="button" data-toggle="collapse"
       data-target="#Navbar" aria-controls="Navbar" aria-expanded="false"
@@ -61,13 +64,6 @@
               </svg>ログイン
             </a>
           </li>
-          <li class="nav-item">
-            <a class="nav-link text-body" href="#" th:href="@{/register}">
-              <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-person-plus-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.5-3a.5.5 0 0 1 .5.5V7h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V8h-1.5a.5.5 0 0 1 0-1H13V5.5a.5.5 0 0 1 .5-.5z"/>
-              </svg>ユーザー登録
-            </a>
-          </li>
          </ul>
        </div>
         <!--* ログイン状態の表示メニュー *-->
@@ -83,14 +79,6 @@
               </a>
             </form>
           </li>
-          <!--* ユーザー登録解除は一般ユーザーのみ表示 *-->
-          <li class="nav-item" sec:authorize="hasRole('USER')">
-            <a class="nav-link text-body" href="#" th:href="@{/exclude}">
-              <svg width="1.25em" height="1.25em" viewBox="0 0 16 16" class="bi bi-person-x-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm6.146-2.854a.5.5 0 0 1 .708 0L14 6.293l1.146-1.147a.5.5 0 0 1 .708.708L14.707 7l1.147 1.146a.5.5 0 0 1-.708.708L14 7.707l-1.146 1.147a.5.5 0 0 1-.708-.708L13.293 7l-1.147-1.146a.5.5 0 0 1 0-.708z"/>
-              </svg>ユーザー登録解除
-            </a>
-          </li>
          </ul>
        </div>
        </div>
@@ -101,6 +89,58 @@
 <section layout:fragment="content">
 <!--* 固有ページで定義する箇所 *-->
 </section>
+
+<!--* ボトムメニュー(画面サイズmd未満のみ表示. 画面下部に追従) -->
+<div class="fixed-bottom d-md-none" id="bottom_menu">
+  <ul class="list-group list-group-horizontal">
+	  <li class="list-group-item list-group-item-primary flex-fill text-body" style="text-align: center;">
+	   <a class="text-body" href="#" th:href="@{/}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="1.5em" height="1.5em" fill="currentColor" class="bi bi-house-door" viewBox="0 0 16 16">
+          <path d="M8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4.5a.5.5 0 0 0 .5-.5v-4h2v4a.5.5 0 0 0 .5.5H14a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146zM2.5 14V7.707l5.5-5.5 5.5 5.5V14H10v-4a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v4H2.5z"/>
+        </svg><br>
+        <span class="small">ホーム</span>
+      </a>
+	  </li>
+	  <li class="list-group-item list-group-item-primary flex-fill text-body" style="text-align: center;">
+	   <a class="text-body" href="#" th:href="@{/todoList}">
+        <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-calendar-week" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+          <path d="M11 6.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm-5 3a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
+        </svg><br>
+       <span class="small">一覧</span>
+      </a>
+	  </li>
+	  <li class="list-group-item list-group-item-primary flex-fill text-body" style="text-align: center;">
+	    <a class="text-body" href="#" th:href="@{/addTodo}">
+        <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-calendar-plus" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+           <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7z"/>
+        </svg><br>
+     <span class="small">追加</span>
+      </a>
+	  </li>
+    <li class="list-group-item list-group-item-primary flex-fill text-body" sec:authorize="isAnonymous()" style="text-align: center;">
+      <a class="text-body" href="#" th:href="@{/loginForm}">
+        <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-box-arrow-in-right" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path fill-rule="evenodd" d="M6 3.5a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 0-1 0v2A1.5 1.5 0 0 0 6.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-8A1.5 1.5 0 0 0 5 3.5v2a.5.5 0 0 0 1 0v-2z"/>
+          <path fill-rule="evenodd" d="M11.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H1.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
+       </svg><br>
+       <span class="small">ログイン</span>
+      </a>
+    </li>
+    <li class="list-group-item list-group-item-primary flex-fill text-body" sec:authorize="isAuthenticated()" style="text-align: center;">
+      <form action="#" th:action="@{/logout}" name="logoutBottomMenu" method="POST">
+        <a class="text-body" href="javascript:logoutBottomMenu.submit()">
+          <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-box-arrow-left" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" d="M6 12.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v2a.5.5 0 0 1-1 0v-2A1.5 1.5 0 0 1 6.5 2h8A1.5 1.5 0 0 1 16 3.5v9a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 5 12.5v-2a.5.5 0 0 1 1 0v2z"/>
+            <path fill-rule="evenodd" d="M.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L1.707 7.5H10.5a.5.5 0 0 1 0 1H1.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
+          </svg>
+        </a>
+      </form>
+      <span class="small">ログアウト</span>
+    </li>
+	</ul>
+</div>
 
 <!--* フッターメニュー(サイトメニュー) *-->
 <footer class="footer mt-auto bg-secondary">

--- a/src/main/resources/templates/login/loginForm.html
+++ b/src/main/resources/templates/login/loginForm.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-	  <div class="container mb-5">
+	  <div class="container mb-5 contents_top">
 	   <h4 class="p-2" style="background-color: #b0c4de;">
         <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-box-arrow-in-right mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
            <path fill-rule="evenodd" d="M6 3.5a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 0-1 0v2A1.5 1.5 0 0 0 6.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-8A1.5 1.5 0 0 0 5 3.5v2a.5.5 0 0 0 1 0v-2z"/>

--- a/src/main/resources/templates/register/confirmRegister.html
+++ b/src/main/resources/templates/register/confirmRegister.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container">
+    <div class="container contents_top">
       <h4 class="p-2" style="background-color: #b0c4de;">
         <svg xmlns="http://www.w3.org/2000/svg" width="0.7em" height="0.7em" fill="currentColor" class="bi bi-check-lg mr-2" viewBox="0 0 16 16">
 				  <path d="M13.485 1.431a1.473 1.473 0 0 1 2.104 2.062l-7.84 9.801a1.473 1.473 0 0 1-2.12.04L.431 8.138a1.473 1.473 0 0 1 2.084-2.083l4.111 4.112 6.82-8.69a.486.486 0 0 1 .04-.045z"/>

--- a/src/main/resources/templates/register/registerForm.html
+++ b/src/main/resources/templates/register/registerForm.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <h4 class="p-2" style="background-color: #b0c4de;">
         <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-person-plus-fill mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.5-3a.5.5 0 0 1 .5.5V7h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V8h-1.5a.5.5 0 0 1 0-1H13V5.5a.5.5 0 0 1 .5-.5z"/>

--- a/src/main/resources/templates/todo/addTodo.html
+++ b/src/main/resources/templates/todo/addTodo.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
     <h4 class="p-2" style="background-color: #b0c4de;">
       <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-plus mb-1 mr-2" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>

--- a/src/main/resources/templates/todo/todoDetails.html
+++ b/src/main/resources/templates/todo/todoDetails.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
     <h4 class="p-2" style="background-color: #b0c4de;">
       <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-card-text align-bottom mr-2" viewBox="0 0 16 16">
 			  <path d="M14.5 3a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h13zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/>

--- a/src/main/resources/templates/todo/todoList.html
+++ b/src/main/resources/templates/todo/todoList.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <section layout:fragment="content">
-    <div class="container mb-5">
+    <div class="container mb-5 contents_top">
       <div class="ml-sm-4">
         <div th:if="${deletedCount ne null}">
 	        <div class="alert alert-warning alert-dismissible fade-show" role="alert">


### PR DESCRIPTION
上部ナビバーは画面サイズに関わらずスクロールに追従しないように変更
それに合わせて、コンテンツ全体のレイアウトを調整

上部ナビバーが折りたたまれる画面サイズをlg->mdに変更
トップページへのスクロールボタンに位置を、ボトムメニューと被らない位置に変更
上部ナビバーが折りたためれる場合の操作補助用のボタンを削除